### PR TITLE
Fix DOI url for figshare entries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.6
+FROM python:3.11.0
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl
 

--- a/slack_figshare.py
+++ b/slack_figshare.py
@@ -75,7 +75,7 @@ def gen_feed_payload(start_msg: str, entries: list, channel: str, day: str) -> d
 def gen_twitter_formatting(data_entries: list) -> list:
     twitter_entries = []
     for entry in data_entries:
-        twitter_entries.append(f"{entry['title']}\nhttps://{entry['doi']}")
+        twitter_entries.append(f"{entry['title']}\nhttps://doi.org/{entry['doi']}")
     return twitter_entries
 
 


### PR DESCRIPTION
* Bump Python version
* Fix DOI url for Figshare entries