### PR TITLE
Only post Figshare .v1 entries in channel

### DIFF
--- a/slack_feeds.py
+++ b/slack_feeds.py
@@ -114,7 +114,7 @@ def post_from_sll_feed(feed_name, channel, path="", name=""):
         if path and not path.endswith("/"):
             path += "/"
         with open(path + helper_filename, "w") as new_last_file:
-            new_last_file.write("\n".join(new_ids + past))
+            new_last_file.write("\n".join((new_ids + past)[:10]))
 
 
 if __name__ == "__main__":

--- a/slack_figshare.py
+++ b/slack_figshare.py
@@ -110,7 +110,7 @@ def post_from_figshare(channel):
     day: str = (datetime.date.today() - datetime.timedelta(days=1)).strftime(
         "%Y-%m-%d"
     )  # Yesterday
-    items: list = get_new_figshare_items(day)
+    items: list = [item for item in get_new_figshare_items(day) if item["doi"].endswith(".v1")]
     if not items:
         return
     formatted_items: list = gen_twitter_formatting(items)

--- a/slack_figshare.py
+++ b/slack_figshare.py
@@ -117,7 +117,7 @@ def post_from_figshare(channel):
 
     start_msg: str = (
         "Here is the latest #opendata item published in @scilifelab "
-        "Data Repository - a service on  http://data.scilifelab.se"
+        "Data Repository - a service on http://data.scilifelab.se"
     )
     payload: dict = gen_feed_payload(start_msg, formatted_items, channel, day)
     post_to_slack(payload)


### PR DESCRIPTION
* Remove extra space
* Filter hits, keeping only the ones with `["doi"].endswith(.v1)`