### PR TITLE
update publications graph

### DIFF
--- a/runner_every10mins.sh
+++ b/runner_every10mins.sh
@@ -2,9 +2,9 @@ export CODE_PATH=/code
 
 # Covid quatification SLU
 PYTHONPATH="$CODE_PATH"/covid-portal-visualisations/wastewater python "$CODE_PATH"/covid-portal-visualisations/wastewater/combined_slu_regular.py > "$CODE_PATH"/output/wastewater_combined_slu_regular.json
-# Covid quatification KTH
-PYTHONPATH="$CODE_PATH"/covid-portal-visualisations/wastewater python "$CODE_PATH"/covid-portal-visualisations/wastewater/combined_stockholm_regular.py > "$CODE_PATH"/output/wastewater_combined_stockholm.json
-PYTHONPATH="$CODE_PATH"/covid-portal-visualisations/wastewater python "$CODE_PATH"/covid-portal-visualisations/wastewater/quant_malmo_kthplot.py > "$CODE_PATH"/output/wastewater_kthmalmo.json
+# Covid quatification KTH (not currently updating)
+#PYTHONPATH="$CODE_PATH"/covid-portal-visualisations/wastewater python "$CODE_PATH"/covid-portal-visualisations/wastewater/combined_stockholm_regular.py > "$CODE_PATH"/output/wastewater_combined_stockholm.json
+#PYTHONPATH="$CODE_PATH"/covid-portal-visualisations/wastewater python "$CODE_PATH"/covid-portal-visualisations/wastewater/quant_malmo_kthplot.py > "$CODE_PATH"/output/wastewater_kthmalmo.json
 # Covid quatification GU
 PYTHONPATH="$CODE_PATH"/covid-portal-visualisations/wastewater python "$CODE_PATH"/covid-portal-visualisations/wastewater/gothenburg_covid.py > "$CODE_PATH"/output/wastewater_gothenburg.json
 # Enteric virus GU

--- a/runner_weekly.sh
+++ b/runner_weekly.sh
@@ -3,7 +3,8 @@ export CODE_PATH=/code
 PYTHONPATH="$CODE_PATH"/covid-portal-visualisations/Wordcloud python "$CODE_PATH"/gen_clouds.py
 
 # Publication related updates
-python "$CODE_PATH"/gen_publication_count.py > "$CODE_PATH"/output/covid-portal-publication-counts.json
+PYTHONPATH="$CODE_PATH"/covid-portal-visualisations/Count_publications python "$CODE_PATH"/covid-portal-visualisations/Count_publications/count_publications.py > "$CODE_PATH"/output/COVID_publication_count.json
+#python "$CODE_PATH"/gen_publication_count.py > "$CODE_PATH"/output/covid-portal-publication-counts.json
 python "$CODE_PATH"/gen_recent_pub.py > "$CODE_PATH"/output/covid-portal-recent10.json
 
 # Upload generated files


### PR DESCRIPTION
Publications graph will now run from the visualisations script in the vis repo, not from the gen_publication_count script. If this works, we can remove the gen_publication_count script from the dynamic repo (as long as it is not interlinked with the recent publications or word cloud scripts). 

Also remove KTH graphs from runner (not updating for now)