### PR TITLE
Fix missed old repo name

### DIFF
--- a/runner_weekly.sh
+++ b/runner_weekly.sh
@@ -3,7 +3,7 @@ export CODE_PATH=/code
 PYTHONPATH="$CODE_PATH"/pathogens-portal-visualisations/Wordcloud python "$CODE_PATH"/gen_clouds.py
 
 # Publication related updates
-PYTHONPATH="$CODE_PATH"/covid-portal-visualisations/Count_publications python "$CODE_PATH"/covid-portal-visualisations/Count_publications/count_publications.py > "$CODE_PATH"/output/COVID_publication_count.json
+PYTHONPATH="$CODE_PATH"/pathogens-portal-visualisations/Count_publications python "$CODE_PATH"/pathogens-portal-visualisations/Count_publications/count_publications.py > "$CODE_PATH"/output/COVID_publication_count.json
 #python "$CODE_PATH"/gen_publication_count.py > "$CODE_PATH"/output/covid-portal-publication-counts.json
 python "$CODE_PATH"/gen_recent_pub.py > "$CODE_PATH"/output/covid-portal-recent10.json
 


### PR DESCRIPTION
After renaming covid portal to pathogens portal, missed it to change in one script. Fixing it now.